### PR TITLE
Replace Ezjsonm with Yojson

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -16,7 +16,7 @@ PKG cohttp.lwt
 PKG cmdliner
 PKG uri
 PKG sexplib
-PKG ezjsonm
+PKG yojson
 PKG ppx_deriving
 PKG ppx_sexp_conv
 PKG ppx_fields_conv

--- a/OMakefile
+++ b/OMakefile
@@ -73,7 +73,7 @@ OCAMLPACKS[] =
   ppx_deriving
   ppx_fields_conv
   ppx_sexp_conv
-  ezjsonm
+  yojson
 
 UNIX_DEPS = cmdliner cohttp.lwt magic-mime lwt.log
 
@@ -82,7 +82,7 @@ BUILD_ROOT = $(dir .)
 SOURCE_DIRS = opium_kernel opium lib_test examples
 
 EXAMPLES_DEPS = $(UNIX_DEPS)
-TEST_DEPS = alcotest ezjsonm
+TEST_DEPS = alcotest yojson
 
 EXAMPLES_ENABLED = true
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ type person = {
   age: int;
 }
 
-let json_of_person { name ; age } =
-  let open Ezjsonm in
-  dict [ "name", (string name)
-       ; "age", (int age) ]
+let json_of_person { name ; age } : Yojson.Safe.json =
+  let open Yojson.Safe in
+  `Assoc
+    [ "name", (`String name)
+    ; "age", (`Int age)
+    ]
 
 let print_param = put "/hello/:name" begin fun req ->
   `String ("Hello " ^ param req "name") |> respond'
@@ -74,7 +76,8 @@ let print_person = get "/person/:name/:age" begin fun req ->
   let person = {
     name = param req "name";
     age = "age" |> param req |> int_of_string;
-  } in
+  }
+  in
   `Json (person |> json_of_person) |> respond'
 end
 

--- a/examples/hello_world.ml
+++ b/examples/hello_world.ml
@@ -5,10 +5,12 @@ type person = {
   age: int;
 }
 
-let json_of_person { name ; age } =
-  let open Ezjsonm in
-  dict [ "name", (string name)
-       ; "age", (int age) ]
+let json_of_person { name ; age } : Yojson.Safe.json =
+  let open Yojson.Safe in
+  `Assoc
+    [ "name", (`String name)
+    ; "age", (`Int age)
+    ]
 
 let print_param = put "/hello/:name" begin fun req ->
   `String ("Hello " ^ param req "name") |> respond'
@@ -18,7 +20,8 @@ let print_person = get "/person/:name/:age" begin fun req ->
   let person = {
     name = param req "name";
     age = "age" |> param req |> int_of_string;
-  } in
+  }
+  in
   `Json (person |> json_of_person) |> respond'
 end
 

--- a/examples/sample.ml
+++ b/examples/sample.ml
@@ -10,8 +10,10 @@ let e3 = get "/xxx/:x/:y" begin fun req ->
   let x = "x" |> param req |> int_of_string in
   let y = "y" |> param req |> int_of_string in
   let sum = float_of_int (x + y) in
-  let open Ezjsonm in
-  `Json (`A [int x; int y;float sum]) |> respond'
+  let open Yojson.Safe in
+  `Json
+    (`List [`Int x; `Int y; `Float sum])
+  |> respond'
 end
 
 let e4 = put "/hello/:x/from/:y" begin fun req ->

--- a/opam
+++ b/opam
@@ -23,7 +23,7 @@ depends: [
   "omake" {build}
   "hmap"
   "cohttp" {>= "0.15.0"}
-  "ezjsonm" {>= "0.4.0"}
+  "yojson" {>= "1.3.3"}
   "base64" {>= "2.0.0"}
   "lwt"
   "cmdliner"

--- a/opium/opium_app.ml
+++ b/opium/opium_app.ml
@@ -225,7 +225,7 @@ let run_command app =
 
 type body = [
   | `Html of string
-  | `Json of Ezjsonm.t
+  | `Json of Yojson.Safe.json
   | `Xml of string
   | `String of string ]
 
@@ -241,7 +241,7 @@ module Response_helpers = struct
   let respond ?headers ?(code=`OK) = function
     | `String s -> respond_with_string ?headers ~code s
     | `Json s ->
-      respond_with_string ~code ~headers:(json_header headers) (Ezjsonm.to_string s)
+      respond_with_string ~code ~headers:(json_header headers) (Yojson.Safe.to_string s)
     | `Html s ->
       respond_with_string ~code ~headers:(html_header headers) s
     | `Xml s ->
@@ -260,7 +260,7 @@ end
 
 module Request_helpers = struct
   let json_exn req =
-    req |> Request.body |> Body.to_string >>| Ezjsonm.from_string
+    req |> Request.body |> Body.to_string >>| Yojson.Safe.from_string
   let string_exn req =
     req |> Request.body |> Body.to_string
   let pairs_exn req =

--- a/opium/opium_app.mli
+++ b/opium/opium_app.mli
@@ -69,11 +69,11 @@ val run_command' : t -> [> `Ok of unit Lwt.t | `Error | `Not_running ]
 (** Convenience functions for a running opium app *)
 type body = [
   | `Html of string
-  | `Json of Ezjsonm.t
+  | `Json of Yojson.Safe.json
   | `Xml of string
   | `String of string ]
 
-val json_of_body_exn : Request.t -> Ezjsonm.t Lwt.t
+val json_of_body_exn : Request.t -> Yojson.Safe.json Lwt.t
 
 val string_of_body_exn : Request.t -> string Lwt.t
 


### PR DESCRIPTION
Many applications use Yojson, probably because of the excellent `ppx_deriving` integration it offers. If these users wish to use opium, they must either switch to Ezjsonm or perform a costly conversion involving stringifying Yojson objects and reparsing them as Ezjsonm objects.